### PR TITLE
added remove and import resource commands

### DIFF
--- a/src/Caster.Api/Caster.Api.csproj
+++ b/src/Caster.Api/Caster.Api.csproj
@@ -12,13 +12,13 @@
     </PackageReference>
     <PackageReference Include="AutoMapper" Version="9.0.0"/>
     <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.6.3.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.0.2" />
     <PackageReference Include="MediatR" Version="8.0.0"/>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.1.0"/>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.0.2"/>
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0"/>
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.0"/>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="7.0.0"/>
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.1.0"/>
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.0.2"/>
     <PackageReference Include="Player.Vm.Api.Client" Version="1.5.0"/>
     <PackageReference Include="IdentityModel" Version="3.10.10"/>
     <PackageReference Include="Polly" Version="7.2.0"/>

--- a/src/Caster.Api/Features/Resources/Commands/Import.cs
+++ b/src/Caster.Api/Features/Resources/Commands/Import.cs
@@ -1,0 +1,78 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using AutoMapper;
+using System.Runtime.Serialization;
+using Caster.Api.Data;
+using System;
+using Caster.Api.Domain.Models;
+using Caster.Api.Infrastructure.Exceptions;
+using Microsoft.AspNetCore.Authorization;
+using Caster.Api.Infrastructure.Authorization;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using Caster.Api.Infrastructure.Options;
+using Caster.Api.Domain.Services;
+using Microsoft.Extensions.Logging;
+using Caster.Api.Infrastructure.Identity;
+using System.Text.Json.Serialization;
+
+namespace Caster.Api.Features.Resources
+{
+    public class Import
+    {
+        [DataContract(Name = "ImportResourceCommand")]
+        public class Command : IRequest<ResourceCommandResult>
+        {
+            /// <summary>
+            /// ID of the Workspace.
+            /// </summary>
+            [JsonIgnore]
+            public Guid WorkspaceId { get; set; }
+
+            /// <summary>
+            /// Address of the Resource to import
+            /// </summary>
+            [DataMember]
+            public string ResourceAddress { get; set; }
+
+            /// <summary>
+            /// Id of the Resource to import
+            /// </summary>
+            [DataMember]
+            public string ResourceId { get; set; }
+        }
+
+        public class Handler : BaseOperationHandler, IRequestHandler<Command, ResourceCommandResult>
+        {
+            public Handler(
+                CasterContext db,
+                IMapper mapper,
+                IAuthorizationService authorizationService,
+                IIdentityResolver identityResolver,
+                TerraformOptions terraformOptions,
+                ITerraformService terraformService,
+                ILockService lockService,
+                ILogger<BaseOperationHandler> logger) :
+            base(db, mapper, authorizationService, identityResolver, terraformOptions, terraformService, lockService, logger)
+            { }
+
+            public async Task<ResourceCommandResult> Handle(Command request, CancellationToken cancellationToken)
+            {
+                if (!(await _authorizationService.AuthorizeAsync(_user, null, new FullRightsRequirement())).Succeeded)
+                    throw new ForbiddenException();
+
+                var workspace = await base.GetWorkspace(request.WorkspaceId);
+
+                return await base.PerformOperation(
+                    workspace,
+                    ResourceOperation.import,
+                    new string[] { request.ResourceAddress },
+                    request.ResourceId);
+            }
+        }
+    }
+}

--- a/src/Caster.Api/Features/Resources/Commands/Refresh.cs
+++ b/src/Caster.Api/Features/Resources/Commands/Refresh.cs
@@ -1,0 +1,62 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using AutoMapper;
+using System.Runtime.Serialization;
+using Caster.Api.Data;
+using System;
+using Caster.Api.Domain.Models;
+using Caster.Api.Infrastructure.Exceptions;
+using Microsoft.AspNetCore.Authorization;
+using Caster.Api.Infrastructure.Authorization;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using Caster.Api.Infrastructure.Options;
+using Caster.Api.Domain.Services;
+using Microsoft.Extensions.Logging;
+using Caster.Api.Infrastructure.Identity;
+using System.Text.Json.Serialization;
+
+namespace Caster.Api.Features.Resources
+{
+    public class Refresh
+    {
+        [DataContract(Name = "RefreshResourcesCommand")]
+        public class Command : IRequest<ResourceCommandResult>
+        {
+            /// <summary>
+            /// ID of the Workspace.
+            /// </summary>
+            [JsonIgnore]
+            public Guid WorkspaceId { get; set; }
+        }
+
+        public class Handler : BaseOperationHandler, IRequestHandler<Command, ResourceCommandResult>
+        {
+            public Handler(
+                CasterContext db,
+                IMapper mapper,
+                IAuthorizationService authorizationService,
+                IIdentityResolver identityResolver,
+                TerraformOptions terraformOptions,
+                ITerraformService terraformService,
+                ILockService lockService,
+                ILogger<BaseOperationHandler> logger) :
+            base(db, mapper, authorizationService, identityResolver, terraformOptions, terraformService, lockService, logger)
+            { }
+
+            public async Task<ResourceCommandResult> Handle(Command request, CancellationToken cancellationToken)
+            {
+                if (!(await _authorizationService.AuthorizeAsync(_user, null, new ContentDeveloperRequirement())).Succeeded)
+                    throw new ForbiddenException();
+
+                var workspace = await base.GetWorkspace(request.WorkspaceId);
+
+                return await base.PerformOperation(workspace, ResourceOperation.refresh, null);
+            }
+        }
+    }
+}

--- a/src/Caster.Api/Features/Resources/Models/Resource.cs
+++ b/src/Caster.Api/Features/Resources/Models/Resource.cs
@@ -54,4 +54,3 @@ namespace Caster.Api.Features.Resources
         public JsonElement? Attributes { get; set; }
     }
 }
-

--- a/src/Caster.Api/Features/Resources/Models/ResourceCommandResult.cs
+++ b/src/Caster.Api/Features/Resources/Models/ResourceCommandResult.cs
@@ -1,0 +1,21 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+namespace Caster.Api.Features.Resources
+{
+    /// <summary>
+    /// Result of a Resource command
+    /// </summary>
+    public class ResourceCommandResult
+    {
+        /// <summary>
+        /// a list of the resulting resources after the command has been executed
+        /// </summary>
+        public Resource[] Resources { get; set; }
+
+        /// <summary>
+        /// a list of errors, if any, encountered during execution of the command
+        /// </summary>
+        public string[] Errors { get; set; }
+    }
+}

--- a/src/Caster.Api/Features/Resources/Queries/GetByWorkspace.cs
+++ b/src/Caster.Api/Features/Resources/Queries/GetByWorkspace.cs
@@ -13,39 +13,24 @@ using Caster.Api.Infrastructure.Exceptions;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Caster.Api.Infrastructure.Authorization;
-using System.Linq;
 using Caster.Api.Infrastructure.Identity;
-using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace Caster.Api.Features.Resources
 {
-    public class Get
+    public class GetByWorkspace
     {
-        [DataContract(Name="GetResourceQuery")]
-        public class Query : IRequest<Resource>
+        [DataContract(Name = "GetResourcesByWorkspaceQuery")]
+        public class Query : IRequest<Resource[]>
         {
             /// <summary>
-            /// Id of the Workspace that the Resource exists in.
+            /// ID of the Workspace.
             /// </summary>
             [JsonIgnore]
             public Guid WorkspaceId { get; set; }
-
-            /// <summary>
-            /// Id of the Resource.
-            /// </summary>
-            [JsonIgnore]
-            public string Id { get; set; }
-
-            /// <summary>
-            /// Type of the Resource.
-            /// </summary>
-            [DataMember]
-            [Required]
-            public string Type { get; set; }
         }
 
-        public class Handler : IRequestHandler<Query, Resource>
+        public class Handler : IRequestHandler<Query, Resource[]>
         {
             private readonly CasterContext _db;
             private readonly IMapper _mapper;
@@ -64,7 +49,7 @@ namespace Caster.Api.Features.Resources
                 _user = identityResolver.GetClaimsPrincipal();
             }
 
-            public async Task<Resource> Handle(Query request, CancellationToken cancellationToken)
+            public async Task<Resource[]> Handle(Query request, CancellationToken cancellationToken)
             {
                 if (!(await _authorizationService.AuthorizeAsync(_user, null, new ContentDeveloperRequirement())).Succeeded)
                     throw new ForbiddenException();
@@ -72,14 +57,13 @@ namespace Caster.Api.Features.Resources
                 var workspace = await _db.Workspaces.FindAsync(request.WorkspaceId);
 
                 if (workspace == null)
+                {
                     throw new EntityNotFoundException<Workspace>();
+                }
 
                 var state = workspace.GetState();
-                var resources = state.GetResources();
-                var resource = resources.Where(r => r.Type == request.Type && r.Id == request.Id).FirstOrDefault();
-                return _mapper.Map<Resource>(resource, opts => opts.ExcludeMembers());
+                return _mapper.Map<Resource[]>(state.GetResources(), opts => opts.ExcludeMembers(nameof(Resource.Attributes)));
             }
         }
     }
 }
-

--- a/src/Caster.Api/Features/Resources/ResourcesController.cs
+++ b/src/Caster.Api/Features/Resources/ResourcesController.cs
@@ -2,7 +2,6 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 using MediatR;
@@ -54,7 +53,7 @@ namespace Caster.Api.Features.Resources
         /// Taint selected Resources
         /// </summary>
         [HttpPost("workspaces/{workspaceId}/resources/actions/taint")]
-        [ProducesResponseType(typeof(Resource[]), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ResourceCommandResult), (int)HttpStatusCode.OK)]
         [SwaggerOperation(OperationId = "TaintResources")]
         public async Task<IActionResult> Taint([FromRoute] Guid workspaceId, [FromBody] Taint.Command command)
         {
@@ -67,7 +66,7 @@ namespace Caster.Api.Features.Resources
         /// Untaint selected Resources
         /// </summary>
         [HttpPost("workspaces/{workspaceId}/resources/actions/untaint")]
-        [ProducesResponseType(typeof(Resource[]), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ResourceCommandResult), (int)HttpStatusCode.OK)]
         [SwaggerOperation(OperationId = "UntaintResources")]
         public async Task<IActionResult> Untaint([FromRoute] Guid workspaceId, [FromBody] Taint.Command command)
         {
@@ -78,16 +77,41 @@ namespace Caster.Api.Features.Resources
         }
 
         /// <summary>
+        /// Remove selected Resources
+        /// </summary>
+        [HttpPost("workspaces/{workspaceId}/resources/actions/remove")]
+        [ProducesResponseType(typeof(ResourceCommandResult), (int)HttpStatusCode.OK)]
+        [SwaggerOperation(OperationId = "RemoveResources")]
+        public async Task<IActionResult> Remove([FromRoute] Guid workspaceId, [FromBody] Remove.Command command)
+        {
+            command.WorkspaceId = workspaceId;
+            var result = await _mediator.Send(command);
+            return Ok(result);
+        }
+
+        /// <summary>
+        /// Import a Resource
+        /// </summary>
+        [HttpPost("workspaces/{workspaceId}/resources/actions/import")]
+        [ProducesResponseType(typeof(ResourceCommandResult), (int)HttpStatusCode.OK)]
+        [SwaggerOperation(OperationId = "ImportResources")]
+        public async Task<IActionResult> Import([FromRoute] Guid workspaceId, [FromBody] Import.Command command)
+        {
+            command.WorkspaceId = workspaceId;
+            var result = await _mediator.Send(command);
+            return Ok(result);
+        }
+
+        /// <summary>
         /// Refresh the Workspace's Resources
         /// </summary>
         [HttpPost("workspaces/{workspaceId}/resources/actions/refresh")]
-        [ProducesResponseType(typeof(Resource[]), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ResourceCommandResult), (int)HttpStatusCode.OK)]
         [SwaggerOperation(OperationId = "RefreshResources")]
         public async Task<IActionResult> Refresh([FromRoute] Guid workspaceId)
         {
-            var result = await _mediator.Send(new Refresh.Command{ WorkspaceId = workspaceId });
+            var result = await _mediator.Send(new Refresh.Command { WorkspaceId = workspaceId });
             return Ok(result);
         }
     }
 }
-


### PR DESCRIPTION
- added remove resources command that implements 'terraform state rm'
  - removes one or more resources from a workspace's state, but DOES NOT affect actual infrastructure
  - common use is if a resource is manually removed outside of terraform it should be removed from terraform's state so it does not try to recreate it
- added import resource command that implements 'terraform import'
  - you must have a configuration block in your terraform config before importing a resource
  - used to bring manually deployed resources into terraform or move resources between workspaces
- added error messages to all resource command results
- updated swashbuckle packages
- fixed resource command output to properly add newlines