### PR TITLE
add credentialstore git config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ EXPOSE 80
 ENV ASPNETCORE_URLS=http://*:80
 CMD [ "dotnet", "Caster.Api.dll" ]
 
-#Install git
-RUN apt-get update && \
-	apt-get install -y git jq
+#Install git and set credential store
+RUN apt-get update              && \
+	apt-get install -y git jq   && \
+    git config --global credential.helper store


### PR DESCRIPTION
Add credential store to caster and use git credentials instead of passing in token, to avoid showing access token in Caster when an error occurs

Internal issue `CRU-881`