### PR TITLE
switch from implicit to auth code

### DIFF
--- a/src/Caster.Api/Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Caster.Api/Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -135,9 +135,10 @@ namespace Caster.Api.Infrastructure.Extensions
                     Type = SecuritySchemeType.OAuth2,
                     Flows = new OpenApiOAuthFlows
                     {
-                        Implicit = new OpenApiOAuthFlow
+                        AuthorizationCode = new OpenApiOAuthFlow
                         {
                             AuthorizationUrl = new Uri(authOptions.AuthorizationUrl),
+                            TokenUrl = new Uri(authOptions.TokenUrl), 
                             Scopes = new Dictionary<string, string>()
                             {
                                 {authOptions.AuthorizationScope, "public api access"}

--- a/src/Caster.Api/Infrastructure/Options/AuthorizationOptions.cs
+++ b/src/Caster.Api/Infrastructure/Options/AuthorizationOptions.cs
@@ -7,6 +7,7 @@ namespace Caster.Api.Infrastructure.Options
     {
         public string Authority { get; set; }
         public string AuthorizationUrl { get; set; }
+        public string TokenUrl { get; set; }
         public string AuthorizationScope { get; set; }
         public string ClientId { get; set; }
         public string ClientName { get; set; }

--- a/src/Caster.Api/Startup.cs
+++ b/src/Caster.Api/Startup.cs
@@ -232,6 +232,7 @@ namespace Caster.Api
                 c.OAuthClientId(_authOptions.ClientId);
                 c.OAuthClientSecret(_authOptions.ClientSecret);
                 c.OAuthAppName(_authOptions.ClientName);
+                c.OAuthUsePkce();
             });
 
             container.Verify();

--- a/src/Caster.Api/appsettings.json
+++ b/src/Caster.Api/appsettings.json
@@ -12,6 +12,7 @@
   "Authorization": {
     "Authority": "https://localhost:5000",
     "AuthorizationUrl": "https://localhost:5000/connect/authorize",
+    "TokenUrl": "http://localhost:5000/connect/token",
     "AuthorizationScope": "caster",
     "ClientId": "caster-api",
     "ClientName": "Caster API",


### PR DESCRIPTION
### Security Fix

Change OAuth2 flow from `Implicit` to `Authorization Code` to follow best practices.

### Breaking Change
Need to add `TokenUrl` to the IdentityServer's `token` endpoint as an appsetting, and update the Client in Identity.

Addresses internal issue `CRU-1842`.