### PR TITLE
Better error message when renaming a locked file

### DIFF
--- a/src/Caster.Api/Features/Files/Requests/Rename.cs
+++ b/src/Caster.Api/Features/Files/Requests/Rename.cs
@@ -64,7 +64,14 @@ namespace Caster.Api.Features.Files
 
                 if(isNotAlreadyLocked)
                 {
-                    file.Lock(userId, isAdmin);
+                    try
+                    {
+                        file.Lock(userId, isAdmin);
+                    }
+                    catch (FileConflictException) 
+                    {
+                        throw new FileConflictException ("Cannot rename a file while it's being edited or locked by another user.");
+                    }
                 }
 
                 try

--- a/src/Caster.Api/Infrastructure/Exceptions/FileConflictException.cs
+++ b/src/Caster.Api/Infrastructure/Exceptions/FileConflictException.cs
@@ -5,8 +5,8 @@ namespace Caster.Api.Infrastructure.Exceptions
 {
     public class FileConflictException : ConflictException
     {
-        public FileConflictException()
-            : base("You cannot make changes to a File without holding it's lock")
+        public FileConflictException(string message = "You cannot make changes to a File without holding it's lock")
+            : base(message)
         {
         }
     }


### PR DESCRIPTION
Provide a more descriptive error message when trying to rename a locked file.  Open to improvements on the error message!

Addresses internal issue `CRU-442`.