### PR TITLE
upgrade to dotnet 6

### DIFF
--- a/.github/workflows/build-client.yml
+++ b/.github/workflows/build-client.yml
@@ -1,10 +1,10 @@
 name: Build Client Package
 
-on: 
+on:
   workflow_dispatch:
     inputs:
       clientVersion:
-        description: 'Version of the Client package'     
+        description: "Version of the Client package"
         required: true
 
 jobs:
@@ -15,7 +15,7 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: "6.0.x"
 
       - name: Setup Package Name
         id: package_name
@@ -28,16 +28,15 @@ jobs:
 
       - name: Build Package
         run: |
-          dotnet new tool-manifest
-          dotnet tool install --version 5.6.3 Swashbuckle.AspNetCore.Cli
           cd ${{ steps.package_name.outputs.directory }}
+          dotnet tool restore
           dotnet build -c Release /p:version=${{ github.event.inputs.clientVersion }}
-          
+
       - name: Run Swagger
         run: |
           cd ${{ steps.package_name.outputs.directory }}
           dotnet swagger tofile --output ../${{ steps.package_name.outputs.name }}/swagger.json bin/Release/*/${{ steps.package_name.outputs.dll_name }}.dll v1
-                    
+
       - name: Run AutoRest
         run: |
           cd src/${{ steps.package_name.outputs.name }}
@@ -63,12 +62,12 @@ jobs:
           sed -i '/<\/version>/a \    <projectUrl>https:\/\/github.com\/cmu-sei\/crucible<\/projectUrl>' ${{ steps.package_name.outputs.name }}.nuspec
           sed -i '/<\/version>/a \    <repository type="git" url="https:\/\/github.com\/cmu-sei\/crucible.git" \/>' ${{ steps.package_name.outputs.name }}.nuspec
           zip -r ../${{ steps.package_name.outputs.name }}.${{ github.event.inputs.clientVersion }}.nupkg *
-       
+
       - name: Publish to Nuget.org as Unlisted
         run: |
           dotnet nuget push src/${{ steps.package_name.outputs.name }}/bin/Release/${{ steps.package_name.outputs.name }}.${{ github.event.inputs.clientVersion }}.nupkg -k ${{ secrets.NUGET_APIKEY }} -s https://api.nuget.org/v3/index.json
           dotnet nuget delete ${{ steps.package_name.outputs.name }} ${{ github.event.inputs.clientVersion }} --non-interactive -k ${{ secrets.NUGET_APIKEY_UNLIST }} -s https://api.nuget.org/v3/index.json
-      
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -81,7 +80,7 @@ jobs:
           prerelease: false
 
       - name: Upload Release Asset
-        id: upload-release-asset 
+        id: upload-release-asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 #multi-stage target: dev
 #
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS dev
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS dev
 
 ENV ASPNETCORE_URLS=http://*:5000 \
     ASPNETCORE_ENVIRONMENT=DEVELOPMENT
@@ -14,7 +14,7 @@ CMD [ "dotnet", "run" ]
 #
 #multi-stage target: prod
 #
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1 AS prod
+FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS prod
 ARG commit
 ENV COMMIT=$commit
 COPY --from=dev /app/dist /app
@@ -25,5 +25,5 @@ CMD [ "dotnet", "Caster.Api.dll" ]
 
 #Install git and set credential store
 RUN apt-get update              && \
-	apt-get install -y git jq   && \
+    apt-get install -y git jq   && \
     git config --global credential.helper store

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+    "sdk": {
+        "version": "6.0.100",
+        "allowPrerelease": false,
+        "rollForward": "latestMinor"
+    }
+}

--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,30 +1,11 @@
-path_classifiers:
-  docs:
-    - generate_javadoc.py
-
-queries:
-  - exclude: "*"
-  - include:           
-      tags:
-        - "security"
-        - "correctness"           
-      severity: "error"
-  - exclude: cpp/use-of-goto
-  - exclude: java/equals-on-unrelated-types
-  - include: java/command-line-injection
-
-extraction: 
-  
+extraction:
   csharp:
     after_prepare:
       - export PATH=$LGTM_WORKSPACE/tools:$PATH
     index:
       all_solutions: false
-      solution: 
+      solution:
         - Caster.API.sln
       build_command:
         - dotnet build src/Caster.Api/Caster.Api.csproj
       buildless: false
-      dotnet:
-        arguments: ""
-        version: 3.1.101

--- a/src/Caster.Api/.config/dotnet-tools.json
+++ b/src/Caster.Api/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "swashbuckle.aspnetcore.cli": {
+      "version": "6.2.3",
+      "commands": [
+        "swagger"
+      ]
+    }
+  }
+}

--- a/src/Caster.Api/Caster.Api.csproj
+++ b/src/Caster.Api/Caster.Api.csproj
@@ -1,43 +1,41 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <noWarn>1591</noWarn>
     <ProjectGuid>{CE177C12-4188-4D93-ABC9-1464D6E5AE81}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.2.3" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.1.1" />
-    <PackageReference Include="MediatR" Version="8.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.0" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.0" />
+    <PackageReference Include="MediatR" Version="9.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.3" />
     <PackageReference Include="Player.Vm.Api.Client" Version="1.5.0" />
-    <PackageReference Include="IdentityModel" Version="3.10.10" />
-    <PackageReference Include="Polly" Version="7.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="2.2.0" />
-    <PackageReference Include="Z.EntityFramework.Plus.EFCore" Version="3.0.32" />
-    <PackageReference Include="SimpleInjector" Version="4.8.1" />
-    <PackageReference Include="SimpleInjector.Integration.AspNetCore" Version="4.8.1" />
-    <PackageReference Include="SimpleInjector.Integration.AspNetCore.Mvc.Core" Version="4.8.1" />
-    <PackageReference Include="SimpleInjector.Integration.GenericHost" Version="4.8.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="3.1.0" />
-    <PackageReference Include="Nito.AsyncEx" Version="5.0.0" />
-    <PackageReference Include="SharpZipLib" Version="1.1.0" />
-    <PackageReference Include="FluentValidation.AspNetCore" Version="9.0.0-preview3" />
-    <PackageReference Include="Macross.Json.Extensions" Version="1.4.1" />
-    <PackageReference Include="NaturalSort.Extension" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="3.1.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="3.1.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="3.1.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.Sqlite" Version="3.1.0" />
+    <PackageReference Include="IdentityModel" Version="6.0.0-preview.3" />
+    <PackageReference Include="Polly" Version="7.2.2" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.1" />
+    <PackageReference Include="SimpleInjector" Version="5.3.2" />
+    <PackageReference Include="SimpleInjector.Integration.AspNetCore" Version="5.3.0" />
+    <PackageReference Include="SimpleInjector.Integration.AspNetCore.Mvc.Core" Version="5.3.0" />
+    <PackageReference Include="SimpleInjector.Integration.GenericHost" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.1" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
+    <PackageReference Include="SharpZipLib" Version="1.3.3" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.6" />
+    <PackageReference Include="Macross.Json.Extensions" Version="2.0.0" />
+    <PackageReference Include="NaturalSort.Extension" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.1-rc2.3" />
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.0" />
+    <PackageReference Include="AspNetCore.HealthChecks.Sqlite" Version="6.0.1-rc2.2" />
   </ItemGroup>
 </Project>

--- a/src/Caster.Api/Domain/Services/AuthenticationService.cs
+++ b/src/Caster.Api/Domain/Services/AuthenticationService.cs
@@ -23,12 +23,15 @@ namespace Caster.Api.Domain.Services
     {
         private readonly Object _lock = new Object();
         private readonly IHttpClientFactory _httpClientFactory;
-        private readonly IOptionsMonitor<ClientOptions> _clientOptions;
+        private readonly IOptionsMonitor<Infrastructure.Options.ClientOptions> _clientOptions;
         private readonly ILogger<AuthenticationService> _logger;
 
         private TokenResponse _tokenResponse;
 
-        public AuthenticationService(IHttpClientFactory httpClientFactory, IOptionsMonitor<ClientOptions> clientOptions, ILogger<AuthenticationService> logger)
+        public AuthenticationService(
+            IHttpClientFactory httpClientFactory,
+            IOptionsMonitor<Infrastructure.Options.ClientOptions> clientOptions,
+            ILogger<AuthenticationService> logger)
         {
             _httpClientFactory = httpClientFactory;
             _clientOptions = clientOptions;
@@ -46,7 +49,7 @@ namespace Caster.Api.Domain.Services
                     if (!ValidateToken())
                     {
                         _tokenResponse = RenewToken(ct);
-                    }                                        
+                    }
                 }
             }
 
@@ -68,7 +71,7 @@ namespace Caster.Api.Domain.Services
             {
                 return true;
             }
-        }        
+        }
 
         private TokenResponse RenewToken(CancellationToken ct)
         {
@@ -87,10 +90,10 @@ namespace Caster.Api.Domain.Services
 
                 return response;
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 _logger.LogError("Exception renewing auth token.", ex);
-            }            
+            }
 
             return null;
         }

--- a/src/Caster.Api/Infrastructure/Extensions/ModelBuilderExtensions.cs
+++ b/src/Caster.Api/Infrastructure/Extensions/ModelBuilderExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
 
 namespace Caster.Api.Infrastructure.Extensions
 {
@@ -62,10 +63,14 @@ namespace Caster.Api.Infrastructure.Extensions
 
             foreach (var entity in builder.Model.GetEntityTypes())
             {
+                var schema = entity.GetSchema();
+                var tableName = entity.GetTableName();
+                var storeObjectIdentifier = StoreObjectIdentifier.Table(tableName, schema);
+
                 // modify column names
                 foreach (var property in entity.GetProperties())
                 {
-                    property.SetColumnName(mapper.TranslateMemberName(property.GetColumnName()));
+                    property.SetColumnName(mapper.TranslateMemberName(property.GetColumnName(storeObjectIdentifier)));
                 }
 
                 // modify table name

--- a/src/Caster.Api/Infrastructure/HttpHandlers/AuthenticatingHandler.cs
+++ b/src/Caster.Api/Infrastructure/HttpHandlers/AuthenticatingHandler.cs
@@ -25,7 +25,7 @@ namespace Caster.Api.Infrastructure.HttpHandlers
         private TokenResponse _token;
         private AuthenticationHeaderValue _authenticationHeader;
 
-        public AuthenticatingHandler(IAuthenticationService authenticationService, ClientOptions clientOptions, ILogger<AuthenticatingHandler> logger)
+        public AuthenticatingHandler(IAuthenticationService authenticationService, Options.ClientOptions clientOptions, ILogger<AuthenticatingHandler> logger)
         {
             _authenticationService = authenticationService;
             _logger = logger;
@@ -67,7 +67,7 @@ namespace Caster.Api.Infrastructure.HttpHandlers
             if (!_token.IsError)
             {
                 _authenticationHeader = new AuthenticationHeaderValue(_token.TokenType, _token.AccessToken);
-            }            
+            }
             else
             {
                 _logger.LogError($"Error in {typeof(AuthenticatingHandler).Name}: {_token.Error}");

--- a/src/Caster.Api/appsettings.json
+++ b/src/Caster.Api/appsettings.json
@@ -10,8 +10,8 @@
     "PostgreSQL": "Server=localhost;Port=5432;Database=caster_api;Username=;Password=;"
   },
   "Authorization": {
-    "Authority": "https://localhost:5000",
-    "AuthorizationUrl": "https://localhost:5000/connect/authorize",
+    "Authority": "http://localhost:5000",
+    "AuthorizationUrl": "http://localhost:5000/connect/authorize",
     "TokenUrl": "http://localhost:5000/connect/token",
     "AuthorizationScope": "caster",
     "ClientId": "caster-api",

--- a/test/Caster.Api.Tests/Caster.Api.Tests.csproj
+++ b/test/Caster.Api.Tests/Caster.Api.Tests.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net60</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0"/>
-    <PackageReference Include="xunit" Version="2.4.0"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
+    <PackageReference Include="xunit" Version="2.4.1"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.1"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Caster.API\Caster.Api.csproj"/>

--- a/test/Caster.Api.Tests/Unit/Terraform/State.cs
+++ b/test/Caster.Api.Tests/Unit/Terraform/State.cs
@@ -137,7 +137,7 @@ namespace Caster.Api.Tests.Unit
             Assert.Equal("vsphere_virtual_machine", machine.Type);
             Assert.Equal($"vsphere_virtual_machine.{addressName}{(count.HasValue ? string.Format("[{0}]", count) : "")}", machine.Address);
             Assert.Equal($"vsphere_virtual_machine.{addressName}", machine.BaseAddress);
-            Assert.Equal(teamId, machine.GetTeamIds().FirstOrDefault());
+            Assert.Equal(teamId, machine.GetTeamIds()?.FirstOrDefault());
         }
 
         [Fact]


### PR DESCRIPTION
- removed incompatible Z.EntityFramework.Plus.EFCore package
- added global.json to make LGTM use dotnet 6
- set default dev identity urls to http instead of https
- fixed a broken unit test