### PR TITLE
added types to altercolumn migrations to make them dotnet 5+ compatible

### DIFF
--- a/src/Caster.Api/Caster.Api.csproj
+++ b/src/Caster.Api/Caster.Api.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="MediatR" Version="9.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.1" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.2" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.3" />
     <PackageReference Include="Player.Vm.Api.Client" Version="1.5.0" />

--- a/src/Caster.Api/Data/Migrations/20190305205435_Changed_Configuration_File_Content_To_String.cs
+++ b/src/Caster.Api/Data/Migrations/20190305205435_Changed_Configuration_File_Content_To_String.cs
@@ -13,9 +13,11 @@ namespace Caster.Api.Data.Migrations
             migrationBuilder.AlterColumn<string>(
                 name: "content",
                 table: "configuration_files",
+                type: "text",
                 nullable: true,
                 oldClrType: typeof(byte[]),
-                oldNullable: true);
+                oldNullable: true,
+                oldType: "bytea");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -23,9 +25,11 @@ namespace Caster.Api.Data.Migrations
             migrationBuilder.AlterColumn<byte[]>(
                 name: "content",
                 table: "configuration_files",
+                type: "bytea",
                 nullable: true,
                 oldClrType: typeof(string),
-                oldNullable: true);
+                oldNullable: true,
+                oldType: "text");
         }
     }
 }

--- a/src/Caster.Api/Data/Migrations/20190313171007_Update_Workspace_State.cs
+++ b/src/Caster.Api/Data/Migrations/20190313171007_Update_Workspace_State.cs
@@ -13,9 +13,11 @@ namespace Caster.Api.Data.Migrations
             migrationBuilder.AlterColumn<string>(
                 name: "state",
                 table: "workspaces",
+                type: "text",
                 nullable: true,
                 oldClrType: typeof(byte[]),
-                oldNullable: true);
+                oldNullable: true,
+                oldType: "bytea");
 
             migrationBuilder.AddColumn<string>(
                 name: "state_backup",
@@ -32,9 +34,11 @@ namespace Caster.Api.Data.Migrations
             migrationBuilder.AlterColumn<byte[]>(
                 name: "state",
                 table: "workspaces",
+                type: "bytea",
                 nullable: true,
                 oldClrType: typeof(string),
-                oldNullable: true);
+                oldNullable: true,
+                oldType: "text");
         }
     }
 }

--- a/src/Caster.Api/Data/Migrations/CasterContextModelSnapshot.cs
+++ b/src/Caster.Api/Data/Migrations/CasterContextModelSnapshot.cs
@@ -53,7 +53,7 @@ namespace Caster.Api.Data.Migrations
                     b.HasIndex("RunId")
                         .IsUnique();
 
-                    b.ToTable("applies");
+                    b.ToTable("applies", (string)null);
                 });
 
             modelBuilder.Entity("Caster.Api.Domain.Models.Directory", b =>
@@ -92,7 +92,7 @@ namespace Caster.Api.Data.Migrations
 
                     b.HasIndex("ProjectId");
 
-                    b.ToTable("directories");
+                    b.ToTable("directories", (string)null);
                 });
 
             modelBuilder.Entity("Caster.Api.Domain.Models.File", b =>
@@ -149,7 +149,7 @@ namespace Caster.Api.Data.Migrations
 
                     b.HasIndex("WorkspaceId");
 
-                    b.ToTable("files");
+                    b.ToTable("files", (string)null);
                 });
 
             modelBuilder.Entity("Caster.Api.Domain.Models.FileVersion", b =>
@@ -200,7 +200,7 @@ namespace Caster.Api.Data.Migrations
 
                     b.HasIndex("TaggedById");
 
-                    b.ToTable("file_versions");
+                    b.ToTable("file_versions", (string)null);
                 });
 
             modelBuilder.Entity("Caster.Api.Domain.Models.Host", b =>
@@ -239,7 +239,7 @@ namespace Caster.Api.Data.Migrations
 
                     b.HasIndex("ProjectId");
 
-                    b.ToTable("hosts");
+                    b.ToTable("hosts", (string)null);
                 });
 
             modelBuilder.Entity("Caster.Api.Domain.Models.HostMachine", b =>
@@ -268,7 +268,7 @@ namespace Caster.Api.Data.Migrations
 
                     b.HasIndex("WorkspaceId");
 
-                    b.ToTable("host_machines");
+                    b.ToTable("host_machines", (string)null);
                 });
 
             modelBuilder.Entity("Caster.Api.Domain.Models.Module", b =>
@@ -297,7 +297,7 @@ namespace Caster.Api.Data.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("modules");
+                    b.ToTable("modules", (string)null);
                 });
 
             modelBuilder.Entity("Caster.Api.Domain.Models.ModuleVersion", b =>
@@ -336,7 +336,7 @@ namespace Caster.Api.Data.Migrations
 
                     b.HasIndex("ModuleId");
 
-                    b.ToTable("module_versions");
+                    b.ToTable("module_versions", (string)null);
                 });
 
             modelBuilder.Entity("Caster.Api.Domain.Models.Permission", b =>
@@ -368,7 +368,7 @@ namespace Caster.Api.Data.Migrations
                     b.HasIndex("Key", "Value")
                         .IsUnique();
 
-                    b.ToTable("permissions");
+                    b.ToTable("permissions", (string)null);
                 });
 
             modelBuilder.Entity("Caster.Api.Domain.Models.Plan", b =>
@@ -396,7 +396,7 @@ namespace Caster.Api.Data.Migrations
                     b.HasIndex("RunId")
                         .IsUnique();
 
-                    b.ToTable("plans");
+                    b.ToTable("plans", (string)null);
                 });
 
             modelBuilder.Entity("Caster.Api.Domain.Models.Project", b =>
@@ -413,7 +413,7 @@ namespace Caster.Api.Data.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("projects");
+                    b.ToTable("projects", (string)null);
                 });
 
             modelBuilder.Entity("Caster.Api.Domain.Models.RemovedResource", b =>
@@ -424,7 +424,7 @@ namespace Caster.Api.Data.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("removed_resources");
+                    b.ToTable("removed_resources", (string)null);
                 });
 
             modelBuilder.Entity("Caster.Api.Domain.Models.Run", b =>
@@ -477,7 +477,7 @@ namespace Caster.Api.Data.Migrations
 
                     b.HasIndex("WorkspaceId");
 
-                    b.ToTable("runs");
+                    b.ToTable("runs", (string)null);
                 });
 
             modelBuilder.Entity("Caster.Api.Domain.Models.User", b =>
@@ -494,7 +494,7 @@ namespace Caster.Api.Data.Migrations
 
                     b.HasKey("Id");
 
-                    b.ToTable("users");
+                    b.ToTable("users", (string)null);
                 });
 
             modelBuilder.Entity("Caster.Api.Domain.Models.UserPermission", b =>
@@ -520,7 +520,7 @@ namespace Caster.Api.Data.Migrations
                     b.HasIndex("UserId", "PermissionId")
                         .IsUnique();
 
-                    b.ToTable("user_permissions");
+                    b.ToTable("user_permissions", (string)null);
                 });
 
             modelBuilder.Entity("Caster.Api.Domain.Models.Workspace", b =>
@@ -573,7 +573,7 @@ namespace Caster.Api.Data.Migrations
 
                     b.HasIndex("HostId");
 
-                    b.ToTable("workspaces");
+                    b.ToTable("workspaces", (string)null);
                 });
 
             modelBuilder.Entity("Caster.Api.Domain.Models.Apply", b =>

--- a/src/Caster.Api/Infrastructure/Extensions/DatabaseExtensions.cs
+++ b/src/Caster.Api/Infrastructure/Extensions/DatabaseExtensions.cs
@@ -45,7 +45,7 @@ namespace Caster.Api.Infrastructure.Extensions
 
         private static void ProcessSeedDataOptions(SeedDataOptions options, CasterContext context)
         {
-            if (options.Permissions.Any())
+            if (options.Permissions?.Any() == true)
             {
                 var dbPermissions = context.Permissions.ToList();
 
@@ -59,7 +59,8 @@ namespace Caster.Api.Infrastructure.Extensions
 
                 context.SaveChanges();
             }
-            if (options.Users.Any())
+
+            if (options.Users?.Any() == true)
             {
                 var dbUsers = context.Users.ToList();
 
@@ -73,7 +74,8 @@ namespace Caster.Api.Infrastructure.Extensions
 
                 context.SaveChanges();
             }
-            if (options.UserPermissions.Any())
+
+            if (options.UserPermissions?.Any() == true)
             {
                 var dbUserPermissions = context.UserPermissions.ToList();
 
@@ -88,7 +90,5 @@ namespace Caster.Api.Infrastructure.Extensions
                 context.SaveChanges();
             }
         }
-
-
     }
 }


### PR DESCRIPTION
- added types to migrations to fix https://github.com/npgsql/efcore.pg/issues/1600
- updated to latest npgsql
- added null cheks to seed data processing