### PR TITLE
improve support for different identity providers

### DIFF
--- a/src/Caster.Api/Infrastructure/ClaimsTransformers/AuthorizationClaimsTransformer.cs
+++ b/src/Caster.Api/Infrastructure/ClaimsTransformers/AuthorizationClaimsTransformer.cs
@@ -4,12 +4,13 @@
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Caster.Api.Domain.Services;
+using Caster.Api.Infrastructure.Extensions;
 using Microsoft.AspNetCore.Authentication;
 
 namespace Caster.Api.Infrastructure.ClaimsTransformers
 {
     class AuthorizationClaimsTransformer : IClaimsTransformation
-    {        
+    {
         private IUserClaimsService _claimsService;
 
         public AuthorizationClaimsTransformer(IUserClaimsService claimsService)
@@ -19,10 +20,11 @@ namespace Caster.Api.Infrastructure.ClaimsTransformers
 
         public async Task<ClaimsPrincipal> TransformAsync(ClaimsPrincipal principal)
         {
-            var user = await _claimsService.AddUserClaims(principal, true);
+            var user = principal.NormalizeScopeClaims();
+            user = await _claimsService.AddUserClaims(user, true);
             _claimsService.SetCurrentClaimsPrincipal(user);
             return user;
-        }       
+        }
     }
 }
 

--- a/src/Caster.Api/Infrastructure/Extensions/AuthorizationPolicyExtension.cs
+++ b/src/Caster.Api/Infrastructure/Extensions/AuthorizationPolicyExtension.cs
@@ -1,23 +1,31 @@
 // Copyright 2021 Carnegie Mellon University. All Rights Reserved.
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.DependencyInjection;
 using Caster.Api.Infrastructure.Authorization;
+using System;
+using Microsoft.AspNetCore.Authorization;
 
 namespace Caster.Api.Infrastructure.Extensions
 {
     public static class AuthorizationPolicyExtensions
     {
-        public static void AddAuthorizationPolicy(this IServiceCollection services)
+        public static void AddAuthorizationPolicy(this IServiceCollection services, Options.AuthorizationOptions authOptions)
         {
             services.AddAuthorization(options =>
             {
+                // Require all scopes in authOptions
+                var policyBuilder = new AuthorizationPolicyBuilder().RequireAuthenticatedUser();
+                Array.ForEach(authOptions.AuthorizationScope.Split(' '), x => policyBuilder.RequireClaim("scope", x));
+
+                options.DefaultPolicy = policyBuilder.Build();
+
                 options.AddPolicy(nameof(CasterClaimTypes.SystemAdmin), policy => policy.Requirements.Add(new FullRightsRequirement()));
                 options.AddPolicy(nameof(CasterClaimTypes.ContentDeveloper), policy => policy.Requirements.Add(new ContentDeveloperRequirement()));
                 options.AddPolicy(nameof(CasterClaimTypes.BaseUser), policy => policy.Requirements.Add(new BaseUserRequirement()));
                 options.AddPolicy(nameof(CasterClaimTypes.Operator), policy => policy.Requirements.Add(new OperatorRequirement()));
             });
+
             services.AddSingleton<IAuthorizationHandler, FullRightsHandler>();
             services.AddSingleton<IAuthorizationHandler, ContentDeveloperHandler>();
             services.AddSingleton<IAuthorizationHandler, OperatorHandler>();

--- a/src/Caster.Api/Infrastructure/Options/AuthorizationOptions.cs
+++ b/src/Caster.Api/Infrastructure/Options/AuthorizationOptions.cs
@@ -13,5 +13,7 @@ namespace Caster.Api.Infrastructure.Options
         public string ClientName { get; set; }
         public string ClientSecret { get; set; }
         public bool RequireHttpsMetadata { get; set; }
+        public bool ValidateAudience { get; set; }
+        public string[] ValidAudiences { get; set; }
     }
 }

--- a/src/Caster.Api/appsettings.json
+++ b/src/Caster.Api/appsettings.json
@@ -17,7 +17,9 @@
     "ClientId": "caster-api",
     "ClientName": "Caster API",
     "ClientSecret": "",
-    "RequireHttpsMetaData": false
+    "RequireHttpsMetaData": false,
+    "ValidateAudience": true,
+    "ValidAudiences": [] // Defaults to AuthorizationScope if null or empty
   },
   "ClaimsTransformation": {
     "EnableCaching": true,
@@ -33,9 +35,7 @@
     "TokenRefreshSeconds": 600
   },
   "CorsPolicy": {
-    "Origins": [
-      "http://localhost:4310"
-    ],
+    "Origins": ["http://localhost:4310"],
     "Methods": [],
     "Headers": [],
     "AllowAnyOrigin": false,


### PR DESCRIPTION
- support scope claims as array or single space-delimited string
- adds ValidateAudience and ValidAudiences settings
  - allows for more granular control of token validation settings
  - defaults to previous behavior