### PR TITLE
fixes variable signalR updates

### DIFF
--- a/src/Caster.Api/Domain/Models/Modules/Variable.cs
+++ b/src/Caster.Api/Domain/Models/Modules/Variable.cs
@@ -42,6 +42,23 @@ public class Variable
         }}";
     }
 
+    /// <summary>
+    /// Computes additional NotMapped modified properties  
+    /// </summary>
+    public string[] GetModifiedProperties(string[] modifiedProperties)
+    {
+        if (modifiedProperties.Contains(nameof(Name)))
+        {
+            var newList = new List<string> { nameof(Terraform) };
+            newList.AddRange(modifiedProperties);
+            return newList.ToArray();
+        }
+        else
+        {
+            return modifiedProperties;
+        }
+    }
+
     private string GetDefaultValueSnippet()
     {
         switch (Type)

--- a/src/Caster.Api/Features/Variables/EventHandlers/SignalREventHandler.cs
+++ b/src/Caster.Api/Features/Variables/EventHandlers/SignalREventHandler.cs
@@ -40,7 +40,7 @@ public class VariableUpdatedSignalRHandler : VariableBaseSignalRHandler, INotifi
         await base.HandleCreateOrUpdate(
             notification.Entity,
             ProjectHubMethods.VariableUpdated,
-            notification.ModifiedProperties.Select(x => x.TitleCaseToCamelCase()).ToArray(),
+            notification.Entity.GetModifiedProperties(notification.ModifiedProperties).Select(x => x.TitleCaseToCamelCase()).ToArray(),
             cancellationToken);
     }
 }


### PR DESCRIPTION
- adds notmapped terraform property to modifiedproperties if name is modified
  - ensures terraform property is updated on the client when a relevant change is made