### PR TITLE
Updated dockerfile to use non-root user

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# directories
+**/bin/
+**/obj/
+**/out/
+
+# files
+Dockerfile*
+**/*.md
+appsettings.*.json
+**/appsettings.*.json


### PR DESCRIPTION
Default docker image now uses a non-root user and port 8080, for increased security. If deploying through Helm, update to the latest Helm chart version with this release to support these changes. You may need to adjust NFS file permissions if mounting any NFS volumes.

Unlike other Crucible applications, Caster is not yet moving to the minimal, shell-less chiseled containers. This is due to needing to install some additional tools in the docker image for some cases. This will be supported out of the box in .NET 10 through chiseled manifest files. At that point, we may switch over.