### PR TITLE
Fix null workspace recovery and improve auth token error logging

### DIFF
--- a/src/Caster.Api/Domain/Services/AuthenticationService.cs
+++ b/src/Caster.Api/Domain/Services/AuthenticationService.cs
@@ -88,11 +88,17 @@ namespace Caster.Api.Domain.Services
                     Password = clientOptions.Password
                 }, ct).Result;
 
+                if (response.IsError)
+                {
+                    _logger.LogError("Error renewing auth token: {Error} - {ErrorDescription}", response.Error, response.ErrorDescription);
+                    return null;
+                }
+
                 return response;
             }
             catch (Exception ex)
             {
-                _logger.LogError("Exception renewing auth token.", ex);
+                _logger.LogError(ex, "Exception renewing auth token");
             }
 
             return null;

--- a/src/Caster.Api/Domain/Services/RunQueueService.cs
+++ b/src/Caster.Api/Domain/Services/RunQueueService.cs
@@ -257,6 +257,14 @@ namespace Caster.Api.Domain.Services
 
                             var workspace = await db.Workspaces.Where(x => x.Id == kvp.Key).FirstOrDefaultAsync();
 
+                            if (workspace == null)
+                            {
+                                _logger.LogWarning("Workspace {WorkspaceId} no longer exists, skipping recovery", kvp.Key);
+                                kvp.Value.Dispose();
+                                disposedLocks.Add(kvp.Key);
+                                continue;
+                            }
+
                             await terraformService.Resume(workspace);
 
                             var workingDir = workspace.GetPath(options.RootWorkingDirectory);


### PR DESCRIPTION
Add null check in RunQueueService to handle deleted workspaces during recovery, and improve AuthenticationService logging to show actual token renewal errors.

Changes:
- RunQueueService: Skip recovery for deleted workspaces instead of throwing NullReferenceException
- AuthenticationService: Check TokenResponse.IsError and log specific error details before returning null
- AuthenticationService: Fix logging format to include exception in structured log output

This prevents startup crashes when workspaces are deleted while runs are in progress, and provides better diagnostics for token renewal failures.