### PR TITLE
Fix null workspace handling in run cancellation and improve error messaging

### DIFF
--- a/src/Caster.Api/Domain/Services/Terraform/KubernetesTerraformService.cs
+++ b/src/Caster.Api/Domain/Services/Terraform/KubernetesTerraformService.cs
@@ -204,14 +204,41 @@ public class KubernetesTerraformService : BaseTerraformService
 
     public override async Task<TerraformResult> CancelRun(Workspace workspace, bool force)
     {
+        if (workspace == null)
+        {
+            _logger.LogWarning("Cannot cancel run - workspace is null");
+            return new TerraformResult
+            {
+                ExitCode = 1,
+                Output = "Workspace not found"
+            };
+        }
+
         var jobName = GetJobName(workspace);
 
-        var job = await _k8sClient.BatchV1.ReadNamespacedJobAsync(jobName, _options.KubernetesJobs.Namespace);
+        V1Job job;
+        try
+        {
+            job = await _k8sClient.BatchV1.ReadNamespacedJobAsync(jobName, _options.KubernetesJobs.Namespace);
+        }
+        catch (HttpOperationException ex) when (ex.Response.StatusCode == HttpStatusCode.NotFound)
+        {
+            _logger.LogDebug("Job {jobName} not found, may have already completed", jobName);
+            return new TerraformResult
+            {
+                ExitCode = 0,
+                Output = "Job not found - may have already completed"
+            };
+        }
 
         if (job == null)
         {
             _logger.LogDebug("Couldn't find job to cancel");
-            return null;
+            return new TerraformResult
+            {
+                ExitCode = 0,
+                Output = "Job not found"
+            };
         }
         else
         {

--- a/src/Caster.Api/Domain/Services/Terraform/ProcessTerraformService.cs
+++ b/src/Caster.Api/Domain/Services/Terraform/ProcessTerraformService.cs
@@ -168,6 +168,11 @@ public class ProcessTerraformService : BaseTerraformService
             if (force)
             {
                 p.Kill();
+                return Task.FromResult(new TerraformResult
+                {
+                    ExitCode = 137,
+                    Output = "Process forcefully terminated"
+                });
             }
             else
             {

--- a/src/Caster.Api/Domain/Services/Terraform/ProcessTerraformService.cs
+++ b/src/Caster.Api/Domain/Services/Terraform/ProcessTerraformService.cs
@@ -153,6 +153,16 @@ public class ProcessTerraformService : BaseTerraformService
 
     public override Task<TerraformResult> CancelRun(Workspace workspace, bool force)
     {
+        if (workspace == null)
+        {
+            _logger.LogWarning("Cannot cancel run - workspace is null");
+            return Task.FromResult(new TerraformResult
+            {
+                ExitCode = 1,
+                Output = "Workspace not found"
+            });
+        }
+
         if (_processCache.TryGetValue(workspace.Id, out Process p))
         {
             if (force)
@@ -202,7 +212,11 @@ public class ProcessTerraformService : BaseTerraformService
             _logger.LogDebug("Couldn't find process to cancel");
         }
 
-        return null;
+        return Task.FromResult(new TerraformResult
+        {
+            ExitCode = 0,
+            Output = "Process not found - may have already completed"
+        });
     }
 
     public override async Task<IEnumerable<Guid>> GetActiveWorkspaces()

--- a/src/Caster.Api/Features/Runs/Requests/Cancel.cs
+++ b/src/Caster.Api/Features/Runs/Requests/Cancel.cs
@@ -58,6 +58,15 @@ namespace Caster.Api.Features.Runs
 
                 ValidateRun(run);
 
+                // Check if workspace still exists before attempting any cancellation
+                if (run.Workspace == null)
+                {
+                    // Workspace was deleted - mark run as failed and return
+                    run.Status = RunStatus.Failed;
+                    await dbContext.SaveChangesAsync(cancellationToken);
+                    throw new InvalidOperationException("Cannot cancel run - workspace no longer exists");
+                }
+
                 if (RunHelpers.QueuedStatuses.Contains(run.Status))
                 {
                     runQueueService.Cancel(run.Id);

--- a/src/Caster.Api/Infrastructure/Exceptions/Middleware/ExceptionMiddleware.cs
+++ b/src/Caster.Api/Infrastructure/Exceptions/Middleware/ExceptionMiddleware.cs
@@ -90,6 +90,12 @@ namespace Caster.Api.Infrastructure.Exceptions.Middleware
                     error.Detail = exception.Message;
                 }
             }
+            else if (exception is WorkspaceConflictException)
+            {
+                error.Title = exception.Message;
+                error.Detail = "Another operation is currently in progress on this workspace. Please wait for it to complete, or contact your administrator if the workspace appears to be stuck.";
+                error.Extensions["type"] = "workspace_locked";
+            }
             else
             {
                 error.Title = exception.Message;


### PR DESCRIPTION
  Fixes critical NullReferenceException when users attempt to cancel runs after workspaces have been deleted, and improves error messaging for workspace
  lock conflicts.

  Related Issue: Production incident in phlprod where workspace stuck in "Applying" status and clicking Cancel threw NullReferenceException.

  Root Cause

  Production runs Caster in ProcessTerraformService mode (not Kubernetes Jobs). The bug occurs when:
  1. A workspace is deleted while a run is still in "Applying" status (orphaned run)
  2. User clicks Cancel button
  3. Cancel.HandleRequest() retrieves the run with .Include(x => x.Workspace) but workspace is null (FK orphan)
  4. Calls ProcessTerraformService.CancelRun(run.Workspace, force)
  5. Line 156: workspace.Id throws NullReferenceException because workspace is null


  Changes

  1. Fix null workspace handling in run cancellation (commit 534bbe5)
  - Cancel.cs: Check for null workspace before attempting any cancellation. If null, mark run as Failed and throw descriptive error.
  - ProcessTerraformService.CancelRun: Add null workspace guard check. Return proper TerraformResult instead of null when process not found.
  - KubernetesTerraformService.CancelRun: Add null workspace guard check and catch HttpOperationException when K8s job doesn't exist (defensive coding for consistency).

  2. Improve WorkspaceConflictException error messaging (commit f8897bd)
  - ExceptionMiddleware.cs: Add specific handling for WorkspaceConflictException to return HTTP 409 Conflict with user-friendly message and guidance.

  Testing

  Tested scenarios:
  - Cancel run with valid workspace (should work normally)
  - Cancel run with deleted workspace (should mark as Failed with clear error)
  - Cancel run when process/job not found (should return gracefully)
  - WorkspaceConflictException returns HTTP 409 with helpful message

  What This Fixes

  ✅ NullReferenceException when canceling runs with deleted workspaces
  ✅ Null return values causing downstream issues
  ✅ Unhandled HttpOperationException in Kubernetes mode (defensive)
  ✅ Unhelpful error messages for workspace lock conflicts
  ✅ Orphaned runs now properly transition to Failed state