### PR TITLE
fix run recovery in Process mode to mark active runs as failed on restart

### DIFF
--- a/src/Caster.Api/Domain/Services/RunQueueService.cs
+++ b/src/Caster.Api/Domain/Services/RunQueueService.cs
@@ -205,7 +205,12 @@ namespace Caster.Api.Domain.Services
 
                 foreach (var run in inProgressRuns)
                 {
-                    if (run.Status == RunStatus.Applying || run.Status == RunStatus.ApplyQueued)
+                    if (!terraformService.SupportsResume &&
+                        (run.Status == RunStatus.Planning || run.Status == RunStatus.Applying))
+                    {
+                        run.Status = RunStatus.Failed;
+                    }
+                    else if (run.Status == RunStatus.Applying || run.Status == RunStatus.ApplyQueued)
                     {
                         Add(new ApplyAdded { ApplyId = run.Apply.Id, RunId = run.Id, WorkspaceId = run.WorkspaceId });
                     }
@@ -214,6 +219,7 @@ namespace Caster.Api.Domain.Services
                         Add(new RunAdded { RunId = run.Id, WorkspaceId = run.WorkspaceId });
                     }
                 }
+                await db.SaveChangesAsync();
 
                 Dictionary<Guid, AsyncLock> locks = new();
                 Dictionary<Guid, AsyncLock.AsyncLockResult> lockResults = new();

--- a/src/Caster.Api/Domain/Services/Terraform/BaseTerraformService.cs
+++ b/src/Caster.Api/Domain/Services/Terraform/BaseTerraformService.cs
@@ -242,6 +242,7 @@ public abstract class BaseTerraformService : ITerraformService
     }
 
     public abstract bool EnableOutputTimer { get; }
+    public abstract bool SupportsResume { get; }
 
     protected abstract string GetBasePath(Workspace workspace);
 

--- a/src/Caster.Api/Domain/Services/Terraform/ITerraformService.cs
+++ b/src/Caster.Api/Domain/Services/Terraform/ITerraformService.cs
@@ -29,6 +29,7 @@ public interface ITerraformService
     Task<IEnumerable<Guid>> GetActiveWorkspaces();
     Task<TerraformResult> Resume(Workspace workspace);
     bool EnableOutputTimer { get; }
+    bool SupportsResume { get; }
 }
 
 public class TerraformResult

--- a/src/Caster.Api/Domain/Services/Terraform/KubernetesTerraformService.cs
+++ b/src/Caster.Api/Domain/Services/Terraform/KubernetesTerraformService.cs
@@ -29,6 +29,7 @@ public class KubernetesTerraformService : BaseTerraformService
     private readonly BackoffTracker _backoffTracker = new(60);
 
     public override bool EnableOutputTimer => false;
+    public override bool SupportsResume => true;
 
     private const string _appName = "caster";
     private const string _appLabel = "app";

--- a/src/Caster.Api/Domain/Services/Terraform/ProcessTerraformService.cs
+++ b/src/Caster.Api/Domain/Services/Terraform/ProcessTerraformService.cs
@@ -20,6 +20,7 @@ namespace Caster.Api.Domain.Services.Terraform;
 public class ProcessTerraformService : BaseTerraformService
 {
     public override bool EnableOutputTimer => true;
+    public override bool SupportsResume => false;
 
     private const string _binaryName = "terraform";
     private readonly ILogger<ProcessTerraformService> _logger;


### PR DESCRIPTION
Summary

  - Add SupportsResume property to ITerraformService to distinguish between execution modes that can survive an app restart (Kubernetes Jobs) and those that cannot (local processes)
  - In RunQueueService.StartRecoverWorkspaces(), mark runs with Planning/Applying status as Failed when the terraform service doesn't support resume, instead of re-queuing them for re-execution
  - Runs that were only Queued/ApplyQueued (no process started yet) are still re-queued as before

  Problem

  When caster-api restarts in Process mode, all child terraform processes are killed. The startup recovery logic was unconditionally re-queuing all in-progress runs, causing terraform plans/applies to be re-executed from scratch. This is incorrect — only Kubernetes Jobs survive an app restart and can be reconnected to.