### PR TITLE
fix null reference exception when cancelling a Run

### DIFF
--- a/src/Caster.Api/Domain/Services/Terraform/KubernetesTerraformService.cs
+++ b/src/Caster.Api/Domain/Services/Terraform/KubernetesTerraformService.cs
@@ -211,7 +211,7 @@ public class KubernetesTerraformService : BaseTerraformService
         if (job == null)
         {
             _logger.LogDebug("Couldn't find job to cancel");
-            return null;
+            return new TerraformResult { ExitCode = 0, Output = "Job not found - may have already completed" };
         }
         else
         {

--- a/src/Caster.Api/Domain/Services/Terraform/ProcessTerraformService.cs
+++ b/src/Caster.Api/Domain/Services/Terraform/ProcessTerraformService.cs
@@ -158,6 +158,11 @@ public class ProcessTerraformService : BaseTerraformService
             if (force)
             {
                 p.Kill();
+                return Task.FromResult(new TerraformResult
+                {
+                    ExitCode = 137,
+                    Output = "Process forcefully terminated"
+                });
             }
             else
             {
@@ -200,9 +205,12 @@ public class ProcessTerraformService : BaseTerraformService
         else
         {
             _logger.LogDebug("Couldn't find process to cancel");
+            return Task.FromResult(new TerraformResult
+            {
+                ExitCode = 0,
+                Output = "Process not found - may have already completed"
+            });
         }
-
-        return null;
     }
 
     public override async Task<IEnumerable<Guid>> GetActiveWorkspaces()


### PR DESCRIPTION
**Summary**

  - Fix ProcessTerraformService.CancelRun returning null when force=true (caused NRE from await null in callers)
  - Fix ProcessTerraformService.CancelRun returning null when process not found in cache
  - Fix KubernetesTerraformService.CancelRun returning null when job not found
  - Add explicit return with exit code 137 for force kill to match SIGKILL convention

 **Problem**

  CancelRun returned null in multiple code paths. Since the caller does await terraformService.CancelRun(...), awaiting a null Task throws a NullReferenceException. This caused 500 errors on every force cancel, even when Kill() succeeded.