### PR TITLE
Kill entire process tree on force cancel

### DIFF
--- a/src/Caster.Api/Domain/Services/Terraform/ProcessTerraformService.cs
+++ b/src/Caster.Api/Domain/Services/Terraform/ProcessTerraformService.cs
@@ -157,7 +157,7 @@ public class ProcessTerraformService : BaseTerraformService
         {
             if (force)
             {
-                p.Kill();
+                p.Kill(true);
             }
             else
             {

--- a/src/Caster.Api/Domain/Services/Terraform/ProcessTerraformService.cs
+++ b/src/Caster.Api/Domain/Services/Terraform/ProcessTerraformService.cs
@@ -157,7 +157,7 @@ public class ProcessTerraformService : BaseTerraformService
         {
             if (force)
             {
-                p.Kill(true);
+                p.Kill(entireProcessTree: true);
             }
             else
             {


### PR DESCRIPTION
**Summary**

  - Change p.Kill() to p.Kill(true) in ProcessTerraformService.CancelRun to kill the entire process tree

  **Problem**

  When force-cancelling a terraform run, only the main terraform process was killed. Terraform spawns provider plugins as child processes that inherit stdout/stderr pipe handles. After killing only the parent, these orphaned children kept the pipes open, causing WaitForExit() in the Run() method to block indefinitely — leaving the apply stuck on Applying forever.