### PR TITLE
Allow specifying directory ID during creation

### DIFF
--- a/src/Caster.Api/Features/Directories/Requests/Create.cs
+++ b/src/Caster.Api/Features/Directories/Requests/Create.cs
@@ -33,6 +33,12 @@ namespace Caster.Api.Features.Directories
         public class Command : IRequest<Directory>, IDirectoryUpdateRequest
         {
             /// <summary>
+            /// Optional ID for the directory. If not provided, one will be generated.
+            /// </summary>
+            [DataMember]
+            public Guid? Id { get; set; }
+
+            /// <summary>
             /// Name of the directory.
             /// </summary>
             [DataMember]
@@ -103,6 +109,13 @@ namespace Caster.Api.Features.Directories
             public override async Task<Directory> HandleRequest(Command request, CancellationToken cancellationToken)
             {
                 var directory = mapper.Map<Domain.Models.Directory>(request);
+
+                // Allow caller to specify the ID
+                if (request.Id.HasValue)
+                {
+                    directory.Id = request.Id.Value;
+                }
+
                 await SetPath(directory);
 
                 dbContext.Directories.Add(directory);
@@ -112,7 +125,11 @@ namespace Caster.Api.Features.Directories
 
             private async Task SetPath(Domain.Models.Directory directory)
             {
-                directory.Id = Guid.NewGuid();
+                // Only generate ID if not already set
+                if (directory.Id == Guid.Empty)
+                {
+                    directory.Id = Guid.NewGuid();
+                }
 
                 if (!directory.ParentId.HasValue)
                 {

--- a/src/Caster.Api/Features/Directories/Requests/Create.cs
+++ b/src/Caster.Api/Features/Directories/Requests/Create.cs
@@ -109,27 +109,16 @@ namespace Caster.Api.Features.Directories
             public override async Task<Directory> HandleRequest(Command request, CancellationToken cancellationToken)
             {
                 var directory = mapper.Map<Domain.Models.Directory>(request);
-
-                // Allow caller to specify the ID
-                if (request.Id.HasValue)
-                {
-                    directory.Id = request.Id.Value;
-                }
-
-                await SetPath(directory);
+                await SetPath(directory, request.Id);
 
                 dbContext.Directories.Add(directory);
                 await dbContext.SaveChangesAsync(cancellationToken);
                 return mapper.Map<Directory>(directory);
             }
 
-            private async Task SetPath(Domain.Models.Directory directory)
+            private async Task SetPath(Domain.Models.Directory directory, Guid? id = null)
             {
-                // Only generate ID if not already set
-                if (directory.Id == Guid.Empty)
-                {
-                    directory.Id = Guid.NewGuid();
-                }
+                directory.Id = id ?? Guid.NewGuid();
 
                 if (!directory.ParentId.HasValue)
                 {


### PR DESCRIPTION
Added optional Id property to Create.Command for directories.

Other Crucible APIs (Player, Alloy, etc.) were updated to allow Blueprint to specify IDs when creating resources. This enables Blueprint to maintain consistent IDs across related entities in different microservices.

Also supports standardized test data creation with predictable IDs.