### PR TITLE
Add validation to prevent deleting projects with active resources or runs

### DIFF
--- a/src/Caster.Api/Features/Directories/Requests/Delete.cs
+++ b/src/Caster.Api/Features/Directories/Requests/Delete.cs
@@ -39,17 +39,25 @@ namespace Caster.Api.Features.Directories
                 if (directory == null)
                     throw new EntityNotFoundException<Directory>();
 
-                var workspaces = await CheckForResources(directory);
+                var (workspacesWithResources, workspacesWithRuns) = await CheckForResourcesAndRuns(directory);
 
-                if (workspaces.Any())
+                if (workspacesWithResources.Any())
                 {
                     string errorMessage = "Cannot delete this Directory due to existing Resources in the following Workspaces:";
-
-                    foreach (var workspace in workspaces)
+                    foreach (var workspace in workspacesWithResources)
                     {
-                        errorMessage += $"\n Name: {workspace.Name}, Id: {workspace.Id} in Directory: {workspace.Directory.Name}, {workspace.DirectoryId}";
+                        errorMessage += $"\n Workspace Id: {workspace.Id}, Directory Id: {workspace.DirectoryId}";
                     }
+                    throw new ConflictException(errorMessage);
+                }
 
+                if (workspacesWithRuns.Any())
+                {
+                    string errorMessage = "Cannot delete this Directory due to pending Runs in the following Workspaces:";
+                    foreach (var workspace in workspacesWithRuns)
+                    {
+                        errorMessage += $"\n Workspace Id: {workspace.Id}, Directory Id: {workspace.DirectoryId}";
+                    }
                     throw new ConflictException(errorMessage);
                 }
 
@@ -57,24 +65,26 @@ namespace Caster.Api.Features.Directories
                 await dbContext.SaveChangesAsync(cancellationToken);
             }
 
-            private async Task<Workspace[]> CheckForResources(Domain.Models.Directory directory)
+            private async Task<(Workspace[], Workspace[])> CheckForResourcesAndRuns(Domain.Models.Directory directory)
             {
                 var directories = await dbContext.Directories
                     .GetChildren(directory, true)
                     .Include(d => d.Workspaces)
                     .ToArrayAsync();
 
-                List<Workspace> workspaces = new List<Workspace>();
+                List<Workspace> workspacesWithResources = new List<Workspace>();
+                List<Workspace> workspacesWithRuns = new List<Workspace>();
 
                 foreach (var workspace in directories.SelectMany(d => d.Workspaces))
                 {
                     if (workspace.GetState().GetResources().Any())
-                    {
-                        workspaces.Add(workspace);
-                    }
+                        workspacesWithResources.Add(workspace);
+
+                    if (await dbContext.AnyIncompleteRuns(workspace.Id))
+                        workspacesWithRuns.Add(workspace);
                 }
 
-                return workspaces.ToArray();
+                return (workspacesWithResources.ToArray(), workspacesWithRuns.ToArray());
             }
         }
     }

--- a/src/Caster.Api/Features/Projects/Requests/Delete.cs
+++ b/src/Caster.Api/Features/Projects/Requests/Delete.cs
@@ -46,6 +46,30 @@ namespace Caster.Api.Features.Projects
                 if (project == null)
                     throw new EntityNotFoundException<Project>();
 
+                // Check all workspaces in this project for deployed resources
+                var workspaces = await dbContext.Workspaces
+                    .Include(w => w.Directory)
+                    .Where(w => w.Directory.ProjectId == request.Id)
+                    .ToListAsync(cancellationToken);
+
+                var workspacesWithResources = new List<Workspace>();
+                var workspacesWithRuns = new List<Workspace>();
+
+                foreach (var workspace in workspaces)
+                {
+                    if (workspace.GetState().GetResources().Any())
+                        workspacesWithResources.Add(workspace);
+
+                    if (await dbContext.AnyIncompleteRuns(workspace.Id))
+                        workspacesWithRuns.Add(workspace);
+                }
+
+                if (workspacesWithResources.Any())
+                    throw new ConflictException("Cannot delete a Project with deployed Resources.");
+
+                if (workspacesWithRuns.Any())
+                    throw new ConflictException("Cannot delete a Project with pending Runs.");
+
                 dbContext.Projects.Remove(project);
                 await dbContext.SaveChangesAsync(cancellationToken);
             }

--- a/src/Caster.Api/Features/Projects/Requests/Delete.cs
+++ b/src/Caster.Api/Features/Projects/Requests/Delete.cs
@@ -2,6 +2,7 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;


### PR DESCRIPTION
Add validation to prevent deleting projects with active resources or runs

- Check all workspaces in project for deployed resources
- Check all workspaces in project for incomplete runs
- Match workspace deletion error message style (generic, no IDs)
- Throw 'Cannot delete a Project with deployed Resources.'
- Throw 'Cannot delete a Project with pending Runs.'