### PR TITLE
Add group manager authorization

### DIFF
--- a/src/Caster.Api/Data/Migrations/20260616135936_Add_GroupMembership_Role.Designer.cs
+++ b/src/Caster.Api/Data/Migrations/20260616135936_Add_GroupMembership_Role.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Caster.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Caster.Api.Data.Migrations
 {
     [DbContext(typeof(CasterContext))]
-    partial class CasterContextModelSnapshot : ModelSnapshot
+    [Migration("20260616135936_Add_GroupMembership_Role")]
+    partial class Add_GroupMembership_Role
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Caster.Api/Data/Migrations/20260616135936_Add_GroupMembership_Role.cs
+++ b/src/Caster.Api/Data/Migrations/20260616135936_Add_GroupMembership_Role.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Caster.Api.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class Add_GroupMembership_Role : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "role",
+                table: "group_memberships",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "role",
+                table: "group_memberships");
+        }
+    }
+}

--- a/src/Caster.Api/Domain/Models/Group.cs
+++ b/src/Caster.Api/Domain/Models/Group.cs
@@ -30,3 +30,9 @@ public class GroupConfiguration : IEntityTypeConfiguration<Group>
         builder.HasIndex(e => e.Name).IsUnique();
     }
 }
+
+public enum GroupPermission
+{
+    ManageMembership,
+    EditGroup
+}

--- a/src/Caster.Api/Domain/Models/GroupMembership.cs
+++ b/src/Caster.Api/Domain/Models/GroupMembership.cs
@@ -21,12 +21,15 @@ public class GroupMembership : IEntity
     public Guid UserId { get; set; }
     public virtual User User { get; set; }
 
+    public GroupMembershipRole Role { get; set; } = GroupMembershipRole.Member;
+
     public GroupMembership() { }
 
-    public GroupMembership(Guid groupId, Guid userId)
+    public GroupMembership(Guid groupId, Guid userId, GroupMembershipRole role = GroupMembershipRole.Member)
     {
         GroupId = groupId;
         UserId = userId;
+        Role = role;
     }
 
     public class GroupMembershipConfiguration : IEntityTypeConfiguration<GroupMembership>
@@ -34,6 +37,8 @@ public class GroupMembership : IEntity
         public void Configure(EntityTypeBuilder<GroupMembership> builder)
         {
             builder.HasIndex(e => new { e.GroupId, e.UserId }).IsUnique();
+
+            builder.Property(x => x.Role).HasDefaultValue(GroupMembershipRole.Member);
 
             builder
                 .HasOne(tu => tu.Group)
@@ -47,4 +52,10 @@ public class GroupMembership : IEntity
                 .HasPrincipalKey(u => u.Id);
         }
     }
+}
+
+public enum GroupMembershipRole
+{
+    Member,
+    Manager
 }

--- a/src/Caster.Api/Domain/Services/UserClaimsService.cs
+++ b/src/Caster.Api/Domain/Services/UserClaimsService.cs
@@ -248,6 +248,23 @@ namespace Caster.Api.Domain.Services
                 claims.Add(new Claim(AuthorizationConstants.ProjectPermissionsClaimType, permissionsClaim.ToString()));
             }
 
+            // Get Group Permissions for Groups the user is a Manager of
+            var managedGroupIds = await _context.GroupMemberships
+                .Where(x => x.UserId == userId && x.Role == GroupMembershipRole.Manager)
+                .Select(x => x.GroupId)
+                .ToListAsync();
+
+            foreach (var groupId in managedGroupIds)
+            {
+                var permissionsClaim = new GroupPermissionsClaim
+                {
+                    GroupId = groupId,
+                    Permissions = [GroupPermission.ManageMembership, GroupPermission.EditGroup]
+                };
+
+                claims.Add(new Claim(AuthorizationConstants.GroupPermissionsClaimType, permissionsClaim.ToString()));
+            }
+
             return claims;
         }
 

--- a/src/Caster.Api/Features/GroupPermissions/GroupPermissionsController.cs
+++ b/src/Caster.Api/Features/GroupPermissions/GroupPermissionsController.cs
@@ -1,0 +1,39 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Caster.Api.Infrastructure.Authorization;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace Caster.Api.Features.GroupPermissions;
+
+[Route("api/permissions/group")]
+[ApiController]
+[Authorize]
+public class GroupPermissionsController : ControllerBase
+{
+    private readonly IMediator _mediator;
+
+    public GroupPermissionsController(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    /// <summary>
+    /// Get all GroupPermissions for the calling User.
+    /// </summary>
+    /// <returns></returns>
+    [HttpGet("mine")]
+    [ProducesResponseType(typeof(IEnumerable<GroupPermissionsClaim>), (int)HttpStatusCode.OK)]
+    [SwaggerOperation(OperationId = "GetMyGroupPermissions")]
+    public async Task<IActionResult> GetAll([FromQuery] GetMine.Query query)
+    {
+        var result = await _mediator.Send(query);
+        return Ok(result);
+    }
+}

--- a/src/Caster.Api/Features/GroupPermissions/Requests/GetMine.cs
+++ b/src/Caster.Api/Features/GroupPermissions/Requests/GetMine.cs
@@ -1,0 +1,34 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using MediatR;
+using System.Runtime.Serialization;
+using Caster.Api.Infrastructure.Authorization;
+using Caster.Api.Features.Shared;
+using System.Linq;
+using System;
+
+namespace Caster.Api.Features.GroupPermissions
+{
+    public class GetMine
+    {
+        [DataContract(Name = "GetMyGroupPermissionsQuery")]
+        public record Query : IRequest<GroupPermissionsClaim[]>
+        {
+            [DataMember]
+            public Guid? GroupId { get; set; }
+        }
+
+        public class Handler(ICasterAuthorizationService authorizationService) : BaseHandler<Query, GroupPermissionsClaim[]>
+        {
+            public override Task<bool> Authorize(Query request, CancellationToken cancellationToken) => Task.FromResult(true);
+
+            public override Task<GroupPermissionsClaim[]> HandleRequest(Query request, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(authorizationService.GetGroupPermissions(request.GroupId).ToArray());
+            }
+        }
+    }
+}

--- a/src/Caster.Api/Features/Groups/GroupMembership.cs
+++ b/src/Caster.Api/Features/Groups/GroupMembership.cs
@@ -2,6 +2,7 @@
 // Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
 
 using System;
+using Caster.Api.Domain.Models;
 
 namespace Caster.Api.Features.Groups
 {
@@ -18,5 +19,10 @@ namespace Caster.Api.Features.Groups
         /// Id of the User.
         /// </summary>
         public Guid UserId { get; set; }
+
+        /// <summary>
+        /// The User's role within the Group.
+        /// </summary>
+        public GroupMembershipRole Role { get; set; }
     }
 }

--- a/src/Caster.Api/Features/Groups/GroupsController.cs
+++ b/src/Caster.Api/Features/Groups/GroupsController.cs
@@ -136,6 +136,22 @@ namespace Caster.Api.Features.Groups
         }
 
         /// <summary>
+        /// Edit a Group Membership.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="command"></param>
+        /// <returns></returns>
+        [HttpPut("memberships/{id}")]
+        [ProducesResponseType(typeof(GroupMembership), (int)HttpStatusCode.OK)]
+        [SwaggerOperation(OperationId = "EditGroupMembership")]
+        public async Task<IActionResult> EditMembership([FromRoute] Guid id, EditMembership.Command command)
+        {
+            command.Id = id;
+            var result = await _mediator.Send(command);
+            return Ok(result);
+        }
+
+        /// <summary>
         /// Delete a Group Membership.
         /// </summary>
         /// <returns></returns>

--- a/src/Caster.Api/Features/Groups/Requests/CreateMembership.cs
+++ b/src/Caster.Api/Features/Groups/Requests/CreateMembership.cs
@@ -36,6 +36,12 @@ namespace Caster.Api.Features.Groups
             /// </summary>
             [DataMember]
             public Guid UserId { get; set; }
+
+            /// <summary>
+            /// The User's role within the Group. Defaults to Member.
+            /// </summary>
+            [DataMember]
+            public GroupMembershipRole Role { get; set; } = GroupMembershipRole.Member;
         }
 
         public class Validator : AbstractValidator<Command>
@@ -50,7 +56,7 @@ namespace Caster.Api.Features.Groups
         public class Handler(ICasterAuthorizationService authorizationService, IMapper mapper, CasterContext dbContext) : BaseHandler<Command, GroupMembership>
         {
             public override async Task<bool> Authorize(Command request, CancellationToken cancellationToken) =>
-                await authorizationService.Authorize([SystemPermission.ManageGroups], cancellationToken);
+                await authorizationService.Authorize<Domain.Models.Group>(request.GroupId, [SystemPermission.ManageGroups], [GroupPermission.ManageMembership], cancellationToken);
 
             public override async Task<GroupMembership> HandleRequest(Command request, CancellationToken cancellationToken)
             {
@@ -60,7 +66,7 @@ namespace Caster.Api.Features.Groups
                 if (groupMembershipExists)
                     throw new ConflictException("User is already a member of this Group");
 
-                var groupMembership = new Domain.Models.GroupMembership(request.GroupId, request.UserId);
+                var groupMembership = new Domain.Models.GroupMembership(request.GroupId, request.UserId, request.Role);
                 dbContext.GroupMemberships.Add(groupMembership);
                 await dbContext.SaveChangesAsync();
 

--- a/src/Caster.Api/Features/Groups/Requests/Edit.cs
+++ b/src/Caster.Api/Features/Groups/Requests/Edit.cs
@@ -36,7 +36,7 @@ namespace Caster.Api.Features.Groups
         public class Handler(ICasterAuthorizationService authorizationService, IMapper mapper, CasterContext dbContext) : BaseHandler<Command, Group>
         {
             public override async Task<bool> Authorize(Command request, CancellationToken cancellationToken) =>
-                await authorizationService.Authorize([SystemPermission.ManageGroups], cancellationToken);
+                await authorizationService.Authorize<Domain.Models.Group>(request.Id, [SystemPermission.ManageGroups], [GroupPermission.EditGroup], cancellationToken);
 
             public override async Task<Group> HandleRequest(Command request, CancellationToken cancellationToken)
             {

--- a/src/Caster.Api/Features/Groups/Requests/EditMembership.cs
+++ b/src/Caster.Api/Features/Groups/Requests/EditMembership.cs
@@ -6,46 +6,49 @@ using System.Threading;
 using System.Threading.Tasks;
 using MediatR;
 using Caster.Api.Data;
+using AutoMapper;
 using System.Runtime.Serialization;
-using Microsoft.EntityFrameworkCore;
-using FluentValidation;
-using Caster.Api.Features.Shared.Services;
-using Caster.Api.Infrastructure.Extensions;
-using System.Linq;
 using System.Text.Json.Serialization;
 using Caster.Api.Infrastructure.Exceptions;
-using Caster.Api.Features.Shared;
 using Caster.Api.Infrastructure.Authorization;
+using Caster.Api.Features.Shared;
 using Caster.Api.Domain.Models;
 
 namespace Caster.Api.Features.Groups
 {
-    public class DeleteMembership
+    public class EditMembership
     {
-        [DataContract(Name = "DeleteGroupMembershipCommand")]
-        public record Command : IRequest
+        [DataContract(Name = "EditGroupMembershipCommand")]
+        public record Command : IRequest<GroupMembership>
         {
             /// <summary>
-            /// The Id of the Group Membership to delete
+            /// The Id of the Group Membership to edit.
             /// </summary>
             [JsonIgnore]
             public Guid Id { get; set; }
+
+            /// <summary>
+            /// The User's role within the Group.
+            /// </summary>
+            [DataMember]
+            public GroupMembershipRole Role { get; set; }
         }
 
-        public class Handler(ICasterAuthorizationService authorizationService, CasterContext dbContext) : BaseHandler<Command>
+        public class Handler(ICasterAuthorizationService authorizationService, IMapper mapper, CasterContext dbContext) : BaseHandler<Command, GroupMembership>
         {
             public override async Task<bool> Authorize(Command request, CancellationToken cancellationToken) =>
                 await authorizationService.Authorize<Domain.Models.GroupMembership>(request.Id, [SystemPermission.ManageGroups], [GroupPermission.ManageMembership], cancellationToken);
 
-            public override async Task HandleRequest(Command request, CancellationToken cancellationToken)
+            public override async Task<GroupMembership> HandleRequest(Command request, CancellationToken cancellationToken)
             {
                 var groupMembership = await dbContext.GroupMemberships.FindAsync([request.Id], cancellationToken);
 
                 if (groupMembership == null)
                     throw new EntityNotFoundException<GroupMembership>();
 
-                dbContext.GroupMemberships.Remove(groupMembership);
-                await dbContext.SaveChangesAsync();
+                groupMembership.Role = request.Role;
+                await dbContext.SaveChangesAsync(cancellationToken);
+                return mapper.Map<GroupMembership>(groupMembership);
             }
         }
     }

--- a/src/Caster.Api/Features/Groups/Requests/Get.cs
+++ b/src/Caster.Api/Features/Groups/Requests/Get.cs
@@ -32,7 +32,7 @@ namespace Caster.Api.Features.Groups
         public class Handler(ICasterAuthorizationService authorizationService, IMapper mapper, CasterContext dbContext) : BaseHandler<Query, Group>
         {
             public override async Task<bool> Authorize(Query request, CancellationToken cancellationToken) =>
-                await authorizationService.Authorize([SystemPermission.ViewGroups], cancellationToken);
+                await authorizationService.Authorize<Domain.Models.Group>(request.Id, [SystemPermission.ViewGroups], [GroupPermission.ManageMembership], cancellationToken);
 
             public override async Task<Group> HandleRequest(Query request, CancellationToken cancellationToken)
             {

--- a/src/Caster.Api/Features/Groups/Requests/GetAll.cs
+++ b/src/Caster.Api/Features/Groups/Requests/GetAll.cs
@@ -32,14 +32,38 @@ namespace Caster.Api.Features.Groups
                     return true;
                 }
 
-                return authorizationService.
+                if (authorizationService.
                     GetProjectPermissions()
-                    .Any(x => x.Permissions.Contains(ProjectPermission.ManageProject));
+                    .Any(x => x.Permissions.Contains(ProjectPermission.ManageProject)))
+                {
+                    return true;
+                }
+
+                return authorizationService.
+                    GetGroupPermissions()
+                    .Any(x => x.Permissions.Contains(GroupPermission.ManageMembership));
             }
 
             public override async Task<Group[]> HandleRequest(Query request, CancellationToken cancellationToken)
             {
-                return await dbContext.Groups
+                var isSystemViewer =
+                    await authorizationService.Authorize([SystemPermission.ViewGroups, SystemPermission.ViewProjects], cancellationToken) ||
+                    authorizationService.GetProjectPermissions().Any(x => x.Permissions.Contains(ProjectPermission.ManageProject));
+
+                var query = dbContext.Groups.AsQueryable();
+
+                if (!isSystemViewer)
+                {
+                    // The user only reached this point because they manage one or more groups,
+                    // so scope the result to just those groups.
+                    var managedIds = authorizationService.GetGroupPermissions()
+                        .Where(x => x.Permissions.Contains(GroupPermission.ManageMembership))
+                        .Select(x => x.GroupId)
+                        .ToList();
+                    query = query.Where(g => managedIds.Contains(g.Id));
+                }
+
+                return await query
                     .ProjectTo<Group>(mapper.ConfigurationProvider)
                     .ToArrayAsync(cancellationToken);
             }

--- a/src/Caster.Api/Features/Groups/Requests/GetMembership.cs
+++ b/src/Caster.Api/Features/Groups/Requests/GetMembership.cs
@@ -35,7 +35,7 @@ namespace Caster.Api.Features.Groups
         public class Handler(ICasterAuthorizationService authorizationService, IMapper mapper, CasterContext dbContext) : BaseHandler<Query, GroupMembership>
         {
             public override async Task<bool> Authorize(Query request, CancellationToken cancellationToken) =>
-                await authorizationService.Authorize([SystemPermission.ViewGroups], cancellationToken);
+                await authorizationService.Authorize<Domain.Models.GroupMembership>(request.Id, [SystemPermission.ViewGroups], [GroupPermission.ManageMembership], cancellationToken);
 
             public override async Task<GroupMembership> HandleRequest(Query request, CancellationToken cancellationToken)
             {

--- a/src/Caster.Api/Features/Groups/Requests/GetMemberships.cs
+++ b/src/Caster.Api/Features/Groups/Requests/GetMemberships.cs
@@ -39,7 +39,7 @@ namespace Caster.Api.Features.Groups
         public class Handler(ICasterAuthorizationService authorizationService, IMapper mapper, CasterContext dbContext) : BaseHandler<Query, GroupMembership[]>
         {
             public override async Task<bool> Authorize(Query request, CancellationToken cancellationToken) =>
-                await authorizationService.Authorize([SystemPermission.ViewGroups], cancellationToken);
+                await authorizationService.Authorize<Domain.Models.Group>(request.GroupId, [SystemPermission.ViewGroups], [GroupPermission.ManageMembership], cancellationToken);
 
             public override async Task<GroupMembership[]> HandleRequest(Query request, CancellationToken cancellationToken)
             {

--- a/src/Caster.Api/Features/Users/Requests/GetAll.cs
+++ b/src/Caster.Api/Features/Users/Requests/GetAll.cs
@@ -37,9 +37,17 @@ namespace Caster.Api.Features.Users
                     return true;
                 }
 
-                return authorizationService.
+                if (authorizationService.
                     GetProjectPermissions()
-                    .Any(x => x.Permissions.Contains(ProjectPermission.ManageProject));
+                    .Any(x => x.Permissions.Contains(ProjectPermission.ManageProject)))
+                {
+                    return true;
+                }
+
+                // Group managers may list users in order to add them to the groups they manage.
+                return authorizationService.
+                    GetGroupPermissions()
+                    .Any(x => x.Permissions.Contains(GroupPermission.ManageMembership));
             }
 
             public override async Task<User[]> HandleRequest(Query request, CancellationToken cancellationToken)

--- a/src/Caster.Api/Hubs/ProjectHub.cs
+++ b/src/Caster.Api/Hubs/ProjectHub.cs
@@ -60,7 +60,7 @@ public class ProjectHub : Hub
 
     public async Task JoinGroup(Guid groupId)
     {
-        if (!await _authorizationService.Authorize([SystemPermission.ViewGroups], Context.ConnectionAborted))
+        if (!await _authorizationService.Authorize<Group>(groupId, [SystemPermission.ViewGroups], [GroupPermission.ManageMembership], Context.ConnectionAborted))
             throw new ForbiddenException();
 
         await Groups.AddToGroupAsync(Context.ConnectionId, groupId.ToString());

--- a/src/Caster.Api/Infrastructure/Authorization/AuthorizationConstants.cs
+++ b/src/Caster.Api/Infrastructure/Authorization/AuthorizationConstants.cs
@@ -12,4 +12,5 @@ public static class AuthorizationConstants
 {
     public const string PermissionsClaimType = "Permission";
     public const string ProjectPermissionsClaimType = "ProjectPermission";
+    public const string GroupPermissionsClaimType = "GroupPermission";
 }

--- a/src/Caster.Api/Infrastructure/Authorization/AuthorizationService.cs
+++ b/src/Caster.Api/Infrastructure/Authorization/AuthorizationService.cs
@@ -30,9 +30,16 @@ public interface ICasterAuthorizationService
         ProjectPermission[] requiredProjectPermissions,
         CancellationToken cancellationToken) where T : IEntity;
 
+    Task<bool> Authorize<T>(
+        Guid? resourceId,
+        SystemPermission[] requiredSystemPermissions,
+        GroupPermission[] requiredGroupPermissions,
+        CancellationToken cancellationToken) where T : IEntity;
+
     IEnumerable<Guid> GetAuthorizedProjectIds();
     IEnumerable<SystemPermission> GetSystemPermissions();
     IEnumerable<ProjectPermissionsClaim> GetProjectPermissions(Guid? projectId = null);
+    IEnumerable<GroupPermissionsClaim> GetGroupPermissions(Guid? groupId = null);
 }
 
 public class AuthorizationService(
@@ -44,7 +51,7 @@ public class AuthorizationService(
         SystemPermission[] requiredSystemPermissions,
         CancellationToken cancellationToken)
     {
-        return await Authorize<IEntity>(null, requiredSystemPermissions, [], cancellationToken);
+        return await Authorize<IEntity>(null, requiredSystemPermissions, Array.Empty<ProjectPermission>(), cancellationToken);
     }
 
     public async Task<bool> Authorize<T>(
@@ -77,6 +84,40 @@ public class AuthorizationService(
                 succeeded = projectPermissionResult.Succeeded;
             }
 
+        }
+
+        return succeeded;
+    }
+
+    public async Task<bool> Authorize<T>(
+        Guid? resourceId,
+        SystemPermission[] requiredSystemPermissions,
+        GroupPermission[] requiredGroupPermissions,
+        CancellationToken cancellationToken) where T : IEntity
+    {
+        bool succeeded = false;
+        var claimsPrincipal = identityResolver.GetClaimsPrincipal();
+        var permissionRequirement = new SystemPermissionRequirement(requiredSystemPermissions);
+        var permissionResult = await authService.AuthorizeAsync(claimsPrincipal, null, permissionRequirement);
+
+        if (permissionResult.Succeeded)
+            succeeded = true;
+
+        if (!succeeded && resourceId.HasValue)
+        {
+            var groupId = await GetGroupId<T>(resourceId.Value, cancellationToken);
+
+            if (groupId == null)
+            {
+                succeeded = false;
+            }
+            else
+            {
+                var groupPermissionRequirement = new GroupPermissionRequirement(requiredGroupPermissions, groupId.Value);
+                var groupPermissionResult = await authService.AuthorizeAsync(claimsPrincipal, null, groupPermissionRequirement);
+
+                succeeded = groupPermissionResult.Succeeded;
+            }
         }
 
         return succeeded;
@@ -118,6 +159,38 @@ public class AuthorizationService(
         }
 
         return permissions;
+    }
+
+    public IEnumerable<GroupPermissionsClaim> GetGroupPermissions(Guid? groupId = null)
+    {
+        var permissions = identityResolver.GetClaimsPrincipal().Claims
+           .Where(x => x.Type == AuthorizationConstants.GroupPermissionsClaimType)
+           .Select(x => GroupPermissionsClaim.FromString(x.Value));
+
+        if (groupId.HasValue)
+        {
+            permissions = permissions.Where(x => x.GroupId == groupId.Value);
+        }
+
+        return permissions;
+    }
+
+    private async Task<Guid?> GetGroupId<T>(Guid resourceId, CancellationToken cancellationToken)
+    {
+        return typeof(T) switch
+        {
+            var t when t == typeof(Group) => resourceId,
+            var t when t == typeof(GroupMembership) => await HandleGroupMembership(resourceId, cancellationToken),
+            _ => throw new NotImplementedException($"Group handler for type {typeof(T).Name} is not implemented.")
+        };
+    }
+
+    private async Task<Guid> HandleGroupMembership(Guid id, CancellationToken cancellationToken)
+    {
+        return await dbContext.GroupMemberships
+            .Where(x => x.Id == id)
+            .Select(x => x.GroupId)
+            .FirstOrDefaultAsync(cancellationToken);
     }
 
     private async Task<Guid?> GetProjectId<T>(Guid resourceId, CancellationToken cancellationToken)

--- a/src/Caster.Api/Infrastructure/Authorization/GroupPermissionClaim.cs
+++ b/src/Caster.Api/Infrastructure/Authorization/GroupPermissionClaim.cs
@@ -1,0 +1,28 @@
+/*
+Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+ Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+*/
+
+using System;
+using System.Text.Json;
+using Caster.Api.Domain.Models;
+
+namespace Caster.Api.Infrastructure.Authorization;
+
+public class GroupPermissionsClaim
+{
+    public Guid GroupId { get; set; }
+    public GroupPermission[] Permissions { get; set; } = [];
+
+    public GroupPermissionsClaim() { }
+
+    public static GroupPermissionsClaim FromString(string json)
+    {
+        return JsonSerializer.Deserialize<GroupPermissionsClaim>(json);
+    }
+
+    public override string ToString()
+    {
+        return JsonSerializer.Serialize(this);
+    }
+}

--- a/src/Caster.Api/Infrastructure/Authorization/GroupPermissionRequirement.cs
+++ b/src/Caster.Api/Infrastructure/Authorization/GroupPermissionRequirement.cs
@@ -1,0 +1,70 @@
+// Copyright 2021 Carnegie Mellon University. All Rights Reserved.
+// Released under a MIT (SEI)-style license. See LICENSE.md in the project root for license information.
+
+using Caster.Api.Domain.Models;
+using Microsoft.AspNetCore.Authorization;
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace Caster.Api.Infrastructure.Authorization
+{
+    public class GroupPermissionRequirement : IAuthorizationRequirement
+    {
+        public GroupPermission[] RequiredPermissions;
+        public Guid GroupId;
+
+        public GroupPermissionRequirement(
+            GroupPermission[] requiredPermissions,
+            Guid groupId)
+        {
+            RequiredPermissions = requiredPermissions;
+            GroupId = groupId;
+        }
+    }
+
+    public class GroupPermissionsHandler : AuthorizationHandler<GroupPermissionRequirement>, IAuthorizationHandler
+    {
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, GroupPermissionRequirement requirement)
+        {
+            if (context.User == null)
+            {
+                context.Fail();
+            }
+            else
+            {
+                GroupPermissionsClaim groupPermissionsClaim = null;
+
+                var claims = context.User.Claims
+                    .Where(x => x.Type == AuthorizationConstants.GroupPermissionsClaimType)
+                    .ToList();
+
+                foreach (var claim in claims)
+                {
+                    var claimValue = GroupPermissionsClaim.FromString(claim.Value);
+                    if (claimValue.GroupId == requirement.GroupId)
+                    {
+                        groupPermissionsClaim = claimValue;
+                        break;
+                    }
+                }
+
+                if (groupPermissionsClaim == null)
+                {
+                    context.Fail();
+                }
+                else if (requirement.RequiredPermissions == null || requirement.RequiredPermissions.Length == 0)
+                {
+                    context.Succeed(requirement);
+                }
+                else if (requirement.RequiredPermissions.Any(x => groupPermissionsClaim.Permissions.Contains(x)))
+                {
+                    context.Succeed(requirement);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Caster.Api/Infrastructure/Extensions/AuthorizationPolicyExtension.cs
+++ b/src/Caster.Api/Infrastructure/Extensions/AuthorizationPolicyExtension.cs
@@ -24,6 +24,7 @@ namespace Caster.Api.Infrastructure.Extensions
 
             services.AddSingleton<IAuthorizationHandler, SystemPermissionsHandler>();
             services.AddSingleton<IAuthorizationHandler, ProjectPermissionsHandler>();
+            services.AddSingleton<IAuthorizationHandler, GroupPermissionsHandler>();
         }
     }
 }


### PR DESCRIPTION
## Summary

This adds group-manager authorization to Caster. A user can now be made a Manager of a specific group and receive scoped permissions for that group without needing broad system-level group administration permissions.

## New Functionality

- Adds a `Role` to group memberships with two values:
  - `Member`: regular group membership.
  - `Manager`: can manage that specific group.
- Adds group-scoped permissions derived from group membership roles:
  - `ManageMembership`: allows managing membership for a group the user manages. Applied to the Manager Role.
  - `EditGroup`: allows editing a group the user manages. Currently unused, but can be added to the Manager Role or a new Role if needed in the future.
- Allows group managers to perform group-level actions for their managed groups without requiring global `ManageGroups` permissions.
- Allows group managers to list users so they can add users to groups they manage.
- Allows group managers to view the groups they manage even if they do not have global group-view permissions.
- Adds an endpoint for clients to retrieve the current user's group permission claims:
  - `GET /api/permissions/group/mine`

## API and Data Changes

- Adds an EF Core migration for `GroupMembership.Role`, defaulting existing memberships to `Member`.
- Adds `EditGroupMembershipCommand` support so a group membership role can be changed.
- Adds generated/API-facing models for group membership roles and group permission claims.
- Extends authorization to evaluate either system permissions or group-scoped permissions depending on the requested group resource.
- Adds group permission claims to user claims generation for group managers.

## Operational Notes

- Existing group memberships become `Member` by default; users must be explicitly promoted to `Manager` to receive scoped group-management permissions.
- This is intended to support the paired Caster UI changes that expose group manager workflows.